### PR TITLE
Update H2_valley_demands.yaml

### DIFF
--- a/data_ES/H2/H2_valley_demands.yaml
+++ b/data_ES/H2/H2_valley_demands.yaml
@@ -3,9 +3,9 @@ H2 valley 0:
 
   valley_name: H2_valley_0
   valley_params:
-    x: -4.0 
-    y: 41.3
-    demand: 0.4   ### H2 annual demand [1e6 tons ~ 33.33 TWh]
+    x: -3.56      # Barajas Airport
+    y: 40.49
+    demand: 0.0315  # Mt/yr
 
   load_name: H2_valley_0_demand
   load_params:
@@ -18,11 +18,102 @@ H2 valley 1:
 
   valley_name: H2_valley_1
   valley_params:
-    x: -2.7 
-    y: 38.0
-    demand: 0.2   ### H2 annual demand [1e6 tons ~ 33.33 TWh]
+    x: 2.08     # El Prat Airport
+    y: 41.30
+    demand: 0.0315  # Mt/yr
 
   load_name: H2_valley_1_demand
   load_params:
     carrier: H2
     bus:          ### to be determined in <prepare_sector_network.py> (the closest one from the network)
+
+
+
+H2 valley 2:
+
+  valley_name: H2_valley_2
+  valley_params:
+    x: -5.69     # Valle Leonés del Hidrógeno Verde (centroid)
+    y: 42.66
+    demand: 0.02545475627  # Mt/yr
+
+  load_name: H2_valley_2_demand
+  load_params:
+    carrier: H2
+    bus:          ### to be determined in <prepare_sector_network.py> (the closest one from the network)
+
+
+
+H2 valley 3:
+
+  valley_name: H2_valley_3
+  valley_params:
+    x: 0.23     # HyBERUS Project (centroid)
+    y: 41.19
+    demand: 0.051  # Mt/yr
+
+  load_name: H2_valley_3_demand
+  load_params:
+    carrier: H2
+    bus:          ### to be determined in <prepare_sector_network.py> (the closest one from the network)
+
+
+
+H2 valley 4:
+
+  valley_name: H2_valley_4
+  valley_params:
+    x: -0.27     # Catalina project
+    y: 39.68
+    demand: 0.01829513173  # Mt/yr
+
+  load_name: H2_valley_4_demand
+  load_params:
+    carrier: H2
+    bus:          ### to be determined in <prepare_sector_network.py> (the closest one from the network)
+
+
+
+H2 valley 5:
+
+  valley_name: H2_valley_5
+  valley_params:
+    x: -8.45     # Valle del Hidrógeno de A Coruña (centroid)
+    y: 43.34
+    demand: 0.01420208813  # Mt/yr
+
+  load_name: H2_valley_5_demand
+  load_params:
+    carrier: H2
+    bus:          ### to be determined in <prepare_sector_network.py> (the closest one from the network)
+
+
+
+H2 valley 6:
+
+  valley_name: H2_valley_6
+  valley_params:
+    x: -6.89     # ONUBA project
+    y: 37.22
+    demand: 0.02551926594  # Mt/yr
+
+  load_name: H2_valley_6_demand
+  load_params:
+    carrier: H2
+    bus:          ### to be determined in <prepare_sector_network.py> (the closest one from the network)
+
+
+
+H2 valley 7:
+
+  valley_name: H2_valley_7
+  valley_params:
+    x: 1.20     # T-HYNET project
+    y: 41.18
+    demand: 0.006528757925  # Mt/yr
+
+  load_name: H2_valley_7_demand
+  load_params:
+    carrier: H2
+    bus:          ### to be determined in <prepare_sector_network.py> (the closest one from the network)
+

--- a/data_ES/H2/H2_valley_demands.yaml
+++ b/data_ES/H2/H2_valley_demands.yaml
@@ -1,3 +1,5 @@
+# Total H2 demand: 204.000 tH2
+# See details at https://github.com/cristobal-GC/pypsa-spain/pull/18
 
 H2 valley 0:
 


### PR DESCRIPTION
Update H2 valley configuration based on the results of the 1st H2 Valleys call ([Resolución definitiva](https://sede.idae.gob.es/sites/default/files/documentos/2025/Hidrogeno/H2%20Valles/Resolucion-definitiva-1ra-convocatoria-Valles-H2.pdf)).

The resolution includes seven funded projects, which are used to define the number of nodes, their locations, and their sector assignment. Node placement follows the proximity-to-consumption scoring criterion from the resolution:
- Projects scoring 4/4 and T-HYNET (3.5/4): node placed at the centroid of the associated municipalities.
- Catalina (0.5/4): end use is industrial at Sagunto via hydrogen pipeline, so the node is placed at the demand site.
- Compostilla Green (0.5/4): end use is aviation (e-SAF); demand is split equally between Madrid-Barajas and Barcelona-El Prat airports.

Demand values per sector are taken from the [Comillas report](https://files.griddo.comillas.edu/20250312-informe-anual-catedra-hidrogeno.pdf), which translates 2030 RED III targets into kt/yr estimates. Each node’s demand is computed in two steps:
1. The share of each project within its sector is calculated based on the project’s expected annual hydrogen production relative to the total production of all funded projects in that sector;
2. This share is then applied to the sector’s total hydrogen demand (kt/year) from the Comillas report, yielding the demand assigned to each node.